### PR TITLE
Build nipkg as part of build pipeline

### DIFF
--- a/build.toml
+++ b/build.toml
@@ -18,3 +18,10 @@ condition = 'lvVersion < 2017'
 name = 'Build SLSC-12201 DIO Custom Device'
 type = 'lvBuildAll'
 project = '{cd}'
+
+[package]
+type = 'nipkg'
+payload_dir = 'Built'
+install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\SLSC Plugins\\Modules'
+2015_install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\Custom Devices\\SLSC Plug-ins'
+2016_install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\Custom Devices\\SLSC Plug-ins'

--- a/control
+++ b/control
@@ -1,0 +1,14 @@
+Package: ni-slsc12201-veristand-{veristand_version}-support
+Version: {nipkg_version}
+Architecture: windows_x64
+Maintainer: National Instruments <support@ni.com>
+XB-Plugin: file
+Description: Provides support for the NI SLSC-12201 DIO custom device for NI VeriStand {veristand_version}.
+XB-Eula: eula-ni-standard
+Priority: standard
+Homepage: http://www.ni.com
+XB-LanguageSupport: en
+XB-UserVisible: yes
+Section: Add-Ons
+XB-DisplayVersion: {display_version}
+XB-DisplayName: NI SLSC-12201 DIO for VeriStand {veristand_version}


### PR DESCRIPTION
- [X] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-12201-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Allows nipkg to be built as part of the 12201 pipeline for release branches.

### Why should this Pull Request be merged?

Testing the actual installers we produce and ship is vital. By building the nipkg installer as part of the build process, our automated test system can validate the exact binaries and installers customers will use.

### What testing has been done?

- Verified installer version matches version of release branch and that installer executes and places correct binaries in the correct location
- Successfully added SLSC-12201 custom device to VeriStand 2018 after installation
