### PR TITLE
Set default build conditional symbol

### DIFF
--- a/Source/SLSC-12201 DIO.lvproj
+++ b/Source/SLSC-12201 DIO.lvproj
@@ -1,6 +1,6 @@
 ﻿<?xml version='1.0' encoding='UTF-8'?>
 <Project Type="Project" LVVersion="15008000">
-	<Property Name="CCSymbols" Type="Str">CD_Version,2015_2016;debug,false;</Property>
+	<Property Name="CCSymbols" Type="Str">CD_Version,Default;debug,false;</Property>
 	<Property Name="NI.LV.All.SourceOnly" Type="Bool">true</Property>
 	<Property Name="NI.Project.Description" Type="Str"></Property>
 	<Property Name="SMProvider.SMVersion" Type="Int">201310</Property>


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-slsc-eds-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Sets the project conditional symbol to **Default** so builds will work out-of-the-box for new LV versions.

### Why should this Pull Request be merged?

Users building manually shouldn't need to modify the project file in order to build for new LV versions. Confirmed with @jashnani.

### What testing has been done?

Built in 2017 and 2018