### PR TITLE
Enable notifications and update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Add names of code owners for this repo
-* @niphilj @buckd
+* @buckd @rtzoeller

--- a/build.toml
+++ b/build.toml
@@ -25,3 +25,6 @@ payload_dir = 'Built'
 install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\SLSC Plugins\\Modules'
 2015_install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\Custom Devices\\SLSC Plug-ins'
 2016_install_destination = 'documents\\National Instruments\\NI VeriStand {veristand_version}\\Custom Devices\\SLSC Plug-ins'
+
+[notification]
+type = 'teams'


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/niveristand-data-sharing-framework-custom-device/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

Enables build notifications to MS Teams
Updates codeowners

### Why should this Pull Request be merged?

Build failures will send notifications and codeowners have changed.

### What testing has been done?

None
